### PR TITLE
Allows for Web3j calls to successfully return errors in a format that Web3j expects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -237,6 +237,7 @@ task runMain() {
         addJvmArgIfEmpty "ethereumj.conf.res", "ethereumj.conf"
         addJvmArgIfEmpty "database.name", "database"
         addJvmArgIfEmpty "networkProfile", "main"
+        addJvmArgIfEmpty "errorResolver.web3jCompliant", "false"
         bootRunWithNetworkConfig('main', false)
     }
 }
@@ -277,6 +278,7 @@ def bootRunWithNetworkConfig(String name, boolean includePresets) {
     def newArgs = []
     if (includePresets) {
         addJvmArgIfEmpty "database.dir", getDatabaseDir("database-" + name)
+        addJvmArgIfEmpty "errorResolver.web3jCompliant", "false"
         newArgs.addAll([
                 '-Dethereumj.conf.res=' + name + '.conf',
                 '-Ddatabase.name=database-' + name,

--- a/src/main/java/com/ethercamp/harmony/config/ApplicationConfig.java
+++ b/src/main/java/com/ethercamp/harmony/config/ApplicationConfig.java
@@ -29,6 +29,8 @@ import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
+import com.ethercamp.harmony.util.exception.Web3jSafeAnnotationsErrorResolver;
+
 /**
  * Created by Stan Reshetnyk on 18.07.16.
  */
@@ -36,15 +38,24 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 @ComponentScan("com.ethercamp")
 public class ApplicationConfig extends WebMvcConfigurerAdapter {
 
+    private final String errorResolverKey = "errorResolver.web3jCompliant";
+
     /**
      * Export bean which will find our json-rpc bean with @JsonRpcService and publish it.
      * https://github.com/briandilley/jsonrpc4j/issues/69
      */
     @Bean
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings({"unchecked", "deprecation"})
     // full class path to avoid deprecation warning
     public com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceExporter exporter() {
-        return new com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceExporter();
+        com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceExporter serviceExporter = new com.googlecode.jsonrpc4j.spring.AutoJsonRpcServiceExporter();
+
+        if (System.getProperty(this.errorResolverKey) != null && 
+            System.getProperty(this.errorResolverKey).toUpperCase().equals("TRUE")) {
+          serviceExporter.setErrorResolver(Web3jSafeAnnotationsErrorResolver.INSTANCE);
+        }
+
+        return serviceExporter;
     }
 
     /**

--- a/src/main/java/com/ethercamp/harmony/util/exception/Web3jSafeAnnotationsErrorResolver.java
+++ b/src/main/java/com/ethercamp/harmony/util/exception/Web3jSafeAnnotationsErrorResolver.java
@@ -1,0 +1,42 @@
+package com.ethercamp.harmony.util.exception;
+
+import com.googlecode.jsonrpc4j.ErrorResolver;
+import com.googlecode.jsonrpc4j.JsonRpcErrors;
+import com.googlecode.jsonrpc4j.JsonRpcError;
+import com.googlecode.jsonrpc4j.ReflectionUtil;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class Web3jSafeAnnotationsErrorResolver implements ErrorResolver {
+
+  public static final Web3jSafeAnnotationsErrorResolver INSTANCE = new Web3jSafeAnnotationsErrorResolver();
+
+    public JsonError resolveError(
+            Throwable t, Method method, List<JsonNode> arguments) {
+
+          JsonRpcErrors errors = ReflectionUtil.getAnnotation(method, JsonRpcErrors.class);
+          
+          if (errors != null) {
+            for (JsonRpcError em : errors.value()) {
+              if (em.exception().isInstance(t)) {
+                String message = em.message()!=null && em.message().trim().length() > 0
+                        ? em.message()
+                        : t.getMessage();
+                
+                // we set the "data" argument to be a simple concatenation of the 
+                // exception's class name and the message; this helps with Web3j's
+                // expectation of a "data" field that is a String, as opposed to the 
+                // defaut Object as defined in the default versions of the ErrorResolver
+                // implementations used with the jsonrpc4j library
+                return new JsonError(em.code(), message,
+                                em.exception().getName() + ": " + message);
+              }
+            }
+          }
+
+          //  none found
+          return null;
+    }
+}


### PR DESCRIPTION
(See the error resolver in this commit for details. Also added a JVM config option that will enable this feature. The feature is disabled by default.)

This PR should address an issue uncovered where making a Web3j call that should not succeed (e.g. trying to send Ether with an unlocked or non-existent account) would cause Web3j to crash. This is due to the expected format of Web3j's error response differing from what is actually provided by Harmony's implementation.

Notes:

- This was put together pretty quickly, but if any quick changes need to be made prior to merging, please advise and I'll have a look.

- Because I've never had much luck with @Value inside an @Configuration class (especially one that is processed early on during startup), I've opted to quickly use the System.getProperty("...") call. I didn't want to spend too much time on this whole mechanism as I'm unfamiliar with your team's style guidelines. I felt that making it a JVM property made the most sense at the moment, though.

- Gradle/Java compilation complains about some input files having unchecked or unsafe operations. I haven't had a chance to look into it as I'm working from command line and haven't had a chance to run it through an IDE.

- The new error resolver class introduced has comments on how exactly it differs from the default one used by the jsonrpc4j library.

- I have tested this out as much as time has allowed (the option works as expected), but only for the "bootRun" target against a private network. I've added default option values into a couple places in the build.gradle file, but for various reasons I can't test those out. I'd recommend testing them out or removing them if necessary.

Thank you for your time and consideration.