### PR TITLE
Moving to use ethereum 1.5.0-RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ dependencies {
     compile "org.ethereum:solcJ-all:0.4.8"                   // Solidity Compiler win/mac/linux binaries
 
     // don't forget to adjust {ethereumJ.version} in application.properties
-    compile ("org.ethereum:ethereumj-core:1.4.2-RELEASE") {
+    compile ("org.ethereum:ethereumj-core:1.5.0-RELEASE") {
         changing = true
 
         exclude group: "log4j"

--- a/src/main/java/com/ethercamp/harmony/jsonrpc/EthJsonRpcImpl.java
+++ b/src/main/java/com/ethercamp/harmony/jsonrpc/EthJsonRpcImpl.java
@@ -597,10 +597,9 @@ public class EthJsonRpcImpl implements JsonRpc {
         }
 
         try {
-            TransactionExecutor executor = commonConfig.transactionExecutor
-                    (tx, block.getCoinbase(), repository, blockStore,
-                            programInvokeFactory, block, new EthereumListenerAdapter(), 0)
-                    .setLocalCall(true);
+            TransactionExecutor executor = new TransactionExecutor(tx, block.getCoinbase(), repository, blockStore,
+                    programInvokeFactory, block, new EthereumListenerAdapter(), 0).withCommonConfig(commonConfig);
+            executor.setLocalCall(true);
 
             executor.init();
             executor.execute();

--- a/src/test/java/com/ethercamp/harmony/jsonrpc/JsonRpcTest.java
+++ b/src/test/java/com/ethercamp/harmony/jsonrpc/JsonRpcTest.java
@@ -121,8 +121,8 @@ public class JsonRpcTest {
 
         @Bean
         @Scope("prototype")
-        public DbSource<byte[]> keyValueDataSource(String s) {
-            System.out.println("Sample DB created name");
+        public DbSource<byte[]> keyValueDataSource(String name) {
+            System.out.println("Sample DB created:" + name);
             return new HashMapDB<byte[]>();
         }
     }

--- a/src/test/java/com/ethercamp/harmony/jsonrpc/JsonRpcTest.java
+++ b/src/test/java/com/ethercamp/harmony/jsonrpc/JsonRpcTest.java
@@ -121,7 +121,7 @@ public class JsonRpcTest {
 
         @Bean
         @Scope("prototype")
-        public DbSource<byte[]> keyValueDataSource() {
+        public DbSource<byte[]> keyValueDataSource(String s) {
             System.out.println("Sample DB created name");
             return new HashMapDB<byte[]>();
         }


### PR DESCRIPTION
Slight change to TransactionExecutor with commonConfig in 1.5 release

called .withCommonConfig

keyValueDataSource now takes string as input, adjusted test accordingly