### PR TITLE
Fix Peer Names

### DIFF
--- a/src/main/java/com/ethercamp/harmony/jsonrpc/EthJsonRpcImpl.java
+++ b/src/main/java/com/ethercamp/harmony/jsonrpc/EthJsonRpcImpl.java
@@ -1335,7 +1335,7 @@ public class EthJsonRpcImpl implements JsonRpc {
         return channelManager.getActivePeers().stream().map(c ->
                 ImmutableMap.of(
                         "id", toJsonHex(c.getNodeId()),
-                        "name", toJsonHex(c.getNodeStatistics().getClientId()),
+                        "name", c.getNodeStatistics().getClientId(),
                         "caps", c.getNodeStatistics().capabilities
                                 .stream()
                                 .filter(cap -> c != null)


### PR DESCRIPTION
Currently, when you request peers from the JSON RPC the names are incorrectly prefixed with "0x"

`"name": "0xGeth/v1.7.3-stable-4bb3c89d/windows-amd64/go1.9"`

I think this fixes it? Issue #43 