### PR TITLE
Added miner statuses

### DIFF
--- a/src/main/java/com/ethercamp/harmony/Application.java
+++ b/src/main/java/com/ethercamp/harmony/Application.java
@@ -44,6 +44,9 @@ public class Application {
      * - perform action and exit on completion.
      */
     public static void main(String[] args) throws Exception {
+        // Overriding mine.start to get control of its startup
+        // in {@link com.ethercamp.harmony.service.PrivateMinerService}
+        SystemProperties.getDefault().overrideParams("mine.start", "false");
         final List<String> actions = asList("importBlocks");
 
         final Optional<String> foundAction = asList(args).stream()

--- a/src/main/java/com/ethercamp/harmony/model/dto/MinerStatusDTO.java
+++ b/src/main/java/com/ethercamp/harmony/model/dto/MinerStatusDTO.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015, 2016 Ether.Camp Inc. (US)
+ * This file is part of Ethereum Harmony.
+ *
+ * Ethereum Harmony is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Ethereum Harmony is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Ethereum Harmony.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ethercamp.harmony.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+/**
+ * Status of Miner
+ */
+@Value
+@AllArgsConstructor
+public class MinerStatusDTO {
+
+    private final String status;
+}

--- a/src/main/java/com/ethercamp/harmony/model/dto/NetworkInfoDTO.java
+++ b/src/main/java/com/ethercamp/harmony/model/dto/NetworkInfoDTO.java
@@ -36,6 +36,8 @@ public class NetworkInfoDTO {
 
     private final SyncStatusDTO syncStatus;
 
+    private final String mineStatus;
+
     private final Integer ethPort;
 
     private final Boolean ethAccessible;

--- a/src/main/java/com/ethercamp/harmony/service/BlockchainInfoService.java
+++ b/src/main/java/com/ethercamp/harmony/service/BlockchainInfoService.java
@@ -108,6 +108,9 @@ public class BlockchainInfoService implements ApplicationListener {
     @Autowired
     FileSystemKeystore keystore;
 
+    @Autowired
+    PrivateMinerService privateMinerService;
+
     /**
      * Concurrent queue of last blocks.
      * Ethereum adds items when available.
@@ -327,6 +330,7 @@ public class BlockchainInfoService implements ApplicationListener {
         final NetworkInfoDTO info = new NetworkInfoDTO(
                 channelManager.getActivePeers().size(),
                 NetworkInfoDTO.SyncStatusDTO.instanceOf(syncManager.getSyncStatus()),
+                privateMinerService.getStatus().toString(),
                 config.listenPort(),
                 true
         );

--- a/src/main/resources/static/js/app/app.controller.js
+++ b/src/main/resources/static/js/app/app.controller.js
@@ -313,6 +313,7 @@
                     $stomp.subscribe('/topic/initialInfo', onInitialInfoResult);
                     $stomp.subscribe('/topic/machineInfo', onMachineInfoResult);
                     $stomp.subscribe('/topic/blockchainInfo', onBlockchainInfoResult);
+                    $stomp.subscribe('/topic/mineInfo', onMineInfoResult);
                     $stomp.subscribe('/topic/newBlockFrom', jsonParseAndBroadcast('newBlockFromEvent'));
                     $stomp.subscribe('/topic/currentSystemLogs', jsonParseAndBroadcast('currentSystemLogs'));
                     $stomp.subscribe('/topic/currentBlocks', jsonParseAndBroadcast('currentBlocksEvent'));
@@ -425,6 +426,22 @@
                 vm.data.gasPrice                = formatBigDigital(info.gasPrice, 'Wei');
                 $scope.setSyncStatus(info.syncStatus);
             });
+        }
+
+        var mineStatuses = {
+            'FULL_DAG_GENERATE': 'Full dataset generating for mining. It could take about 10 minutes',
+            'DAG_GENERATED': 'Dataset generated. Mining will start shortly',
+            'MINING': 'Mining initiated',
+            'DISABLED': 'Mining stopped'
+        };
+
+        function onMineInfoResult(data) {
+            var info = (data);
+
+            var msg = mineStatuses[info.status];
+            if (msg != null) {
+                showToastr(msg, '');
+            }
         }
 
         function onConfirmedTransaction(data) {

--- a/src/main/resources/static/js/app/home.controller.js
+++ b/src/main/resources/static/js/app/home.controller.js
@@ -29,6 +29,7 @@
 
         $scope.activePeers = 0;
         $scope.syncStatus = 'n/a';
+        $scope.mineStatus = 'n/a';
         $scope.syncStatusMessageTop = '';
         $scope.syncStatusMessageBottom = '';
         $scope.ethPort = 'n/a';
@@ -45,6 +46,14 @@
             'Regular': 'Long sync',
             'Complete': 'Short sync',
             'Off': 'Disabled'
+        };
+
+        var mineStatuses = {
+            'LIGHT_DAG_GENERATE': 'Generating light dataset',
+            'FULL_DAG_GENERATE': 'Generating full dataset (10 min)',
+            'DAG_GENERATED': 'Dataset generated, mining',
+            'MINING': 'Mining',
+            'DISABLED': 'Disabled'
         };
 
         var syncStatusesMessageTop = {
@@ -114,6 +123,7 @@
             $timeout(function() {
                 $scope.activePeers = item.activePeers;
                 $scope.syncStatus = formatWithProps(syncStatuses[item.syncStatus.stage], item.syncStatus) || item.syncStatus.stage || 'n/a';
+                $scope.mineStatus = mineStatuses[item.mineStatus] || 'n/a';
                 $scope.syncStatusMessageTop = formatWithProps(syncStatusesMessageTop[item.syncStatus.stage], item.syncStatus);
                 if (item.syncStatus.stage == 'StateNodes' && item.syncStatus.curCnt > 0 && item.syncStatus.curCnt == item.syncStatus.knownCnt) {
                     $scope.syncStatusMessageBottom = formatWithProps(syncStatusesMessageBottom['StateNodesBlocks'], item.syncStatus);

--- a/src/main/resources/static/pages/home.html
+++ b/src/main/resources/static/pages/home.html
@@ -49,19 +49,19 @@
 
                         <div class="home-info-row">
                             <div class="col-sm-4">
-                                Started:
+                                Sync status:
                             </div>
-                            <div class="col-sm-6">
-                                {{vm.data.serverStartTime}}
+                            <div class="col-sm-8">
+                                {{syncStatus}}
                             </div>
                         </div>
 
                         <div class="home-info-row">
                             <div class="col-sm-4">
-                                Sync status:
+                                Mine status:
                             </div>
-                            <div class="col-sm-8">
-                                {{syncStatus}}
+                            <div class="col-sm-6">
+                                {{mineStatus}}
                             </div>
                         </div>
 


### PR DESCRIPTION
@mkalinin we need to think out how to solve miner issue:
EthereumJ is parsing configs on very early stage, after that `BlockMiner` `@Autowired` gets in and starts mining and generating dataset. So we have no simple way to add listener before dataset generation starts. Even if we have something on our side with `@Autowired`, not postInit like we have now, we couldn't guarantee order. So I've solved this issue in very stinky way: take a look at `Application.java` and `PrivateMinerService.java` (116 - 119 lines).
Also I appreciate any UX comments!