### PR TITLE
Fix  "Variable might not have been initialized"

### DIFF
--- a/src/main/java/com/ethercamp/harmony/jsonrpc/JsonRpc.java
+++ b/src/main/java/com/ethercamp/harmony/jsonrpc/JsonRpc.java
@@ -45,9 +45,9 @@ public interface JsonRpc {
     @AllArgsConstructor
     @ToString
     class SyncingResult {
-        private final String startingBlock;
-        private final String currentBlock;
-        private final String highestBlock;
+        private final String startingBlock = null;
+        private final String currentBlock = null;
+        private final String highestBlock = null;
     }
 
     @NoArgsConstructor


### PR DESCRIPTION
When I compile the project source code with IntelliJ IDEA, a compilation error "Variable XXX might not have been initialized" appears. My development environment is JDK1.8.