### PR TITLE
toJsonHex with an empty byte array produces "0x" which does not work in the remix IDE

### DIFF
--- a/src/main/java/com/ethercamp/harmony/jsonrpc/TypeConverter.java
+++ b/src/main/java/com/ethercamp/harmony/jsonrpc/TypeConverter.java
@@ -61,7 +61,7 @@ public class TypeConverter {
      * "0x" for null
      */
     public static String toJsonHex(byte[] x) {
-        return x == null ? null : "0x" + Hex.toHexString(x);
+        return x == null ? null : toJsonHex(Hex.toHexString(x));
     }
 
     /**
@@ -69,11 +69,11 @@ public class TypeConverter {
      * null for null
      */
     public static String toJsonHexNullable(byte[] x) {
-        return x == null ? null : "0x" + Hex.toHexString(x);
+        return x == null ? null : toJsonHex(Hex.toHexString(x));
     }
 
     public static String toJsonHex(String x) {
-        return "0x"+x;
+        return x.isEmpty() ? "0x0" : "0x"+x;
     }
 
     public static String toJsonHex(int x) {


### PR DESCRIPTION
{"jsonrpc":"2.0","id":63,"result":{"hash":"0x4f2a5...","nonce":"0x00",
"blockHash":"0x57698...","blockNumber":"0x2","transactionIndex":"0x0",
"from":"0x5c5a...","to":"0x","gas":"0x012118","gasPrice":"0x0ba43b7400",
"value":"0x","input":"0x608060405260..."}}

The problem with "to":"0x" and "value":"0x" is that the remix IDE cannot
convert those numbers and throws the following exception:
"Error: new BigNumber() not a base 16 number"

This fix checks if the byte array or the resulting string is empty and
if it is the case it returns 0x0. This fixes the issue with the remix
IDE