### PR TITLE
toJsonHex with an empty byte array produces "0x" which does not work in the remix IDE

### DIFF
--- a/src/main/java/com/ethercamp/harmony/jsonrpc/TransactionResultDTO.java
+++ b/src/main/java/com/ethercamp/harmony/jsonrpc/TransactionResultDTO.java
@@ -51,7 +51,7 @@ public class TransactionResultDTO {
         blockNumber = toJsonHex(b.getNumber());
         transactionIndex = toJsonHex(index);
         from= toJsonHex(tx.getSender());
-        to = tx.getReceiveAddress() == null || tx.getReceiveAddress().length == 0 ? null : toJsonHex(tx.getReceiveAddress());
+        to = tx.getReceiveAddress() == null ? null : toJsonHex(tx.getReceiveAddress());
         gas = toJsonHex(tx.getGasLimit());
         gasPrice = toJsonHex(tx.getGasPrice());
         value = toJsonHexNumber(tx.getValue());

--- a/src/main/java/com/ethercamp/harmony/jsonrpc/TransactionResultDTO.java
+++ b/src/main/java/com/ethercamp/harmony/jsonrpc/TransactionResultDTO.java
@@ -23,6 +23,7 @@ import org.ethereum.core.Block;
 import org.ethereum.core.Transaction;
 
 import static com.ethercamp.harmony.jsonrpc.TypeConverter.toJsonHex;
+import static com.ethercamp.harmony.jsonrpc.TypeConverter.toJsonHexNumber;
 
 /**
  * Created by Ruben on 8/1/2016.
@@ -50,10 +51,10 @@ public class TransactionResultDTO {
         blockNumber = toJsonHex(b.getNumber());
         transactionIndex = toJsonHex(index);
         from= toJsonHex(tx.getSender());
-        to = tx.getReceiveAddress() == null ? null : toJsonHex(tx.getReceiveAddress());
+        to = tx.getReceiveAddress() == null || tx.getReceiveAddress().length == 0 ? null : toJsonHex(tx.getReceiveAddress());
         gas = toJsonHex(tx.getGasLimit());
         gasPrice = toJsonHex(tx.getGasPrice());
-        value = toJsonHex(tx.getValue());
+        value = toJsonHexNumber(tx.getValue());
         input  = tx.getData() != null ? toJsonHex(tx.getData()) : null;
     }
 

--- a/src/main/java/com/ethercamp/harmony/jsonrpc/TypeConverter.java
+++ b/src/main/java/com/ethercamp/harmony/jsonrpc/TypeConverter.java
@@ -72,6 +72,11 @@ public class TypeConverter {
         return x == null ? null : "0x" + Hex.toHexString(x);
     }
 
+    public static String toJsonHexNumber(byte[] x) {
+        String hex = Hex.toHexString(x);
+        return toJsonHex(hex.isEmpty() ? "0" : hex);
+    }
+
     public static String toJsonHex(String x) {
         return "0x"+x;
     }

--- a/src/main/java/com/ethercamp/harmony/jsonrpc/TypeConverter.java
+++ b/src/main/java/com/ethercamp/harmony/jsonrpc/TypeConverter.java
@@ -67,7 +67,7 @@ public class TypeConverter {
 
     public static String toJsonHexNumber(byte[] x) {
         if(x == null) {
-            return null;
+            return "0x0";
         }
         String hex = Hex.toHexString(x);
         return toJsonHex(hex.isEmpty() ? "0" : hex);

--- a/src/main/java/com/ethercamp/harmony/jsonrpc/TypeConverter.java
+++ b/src/main/java/com/ethercamp/harmony/jsonrpc/TypeConverter.java
@@ -73,6 +73,9 @@ public class TypeConverter {
     }
 
     public static String toJsonHexNumber(byte[] x) {
+        if(x == null) {
+            return null;
+        }
         String hex = Hex.toHexString(x);
         return toJsonHex(hex.isEmpty() ? "0" : hex);
     }


### PR DESCRIPTION
The problem with "to":"0x" and "value":"0x" is that the remix IDE cannot
convert those numbers and addresses and throws the following exception:
"Error: new BigNumber() not a base 16 number". For the gettransactionreceipt, the JSON looks as follows:

{"jsonrpc":"2.0","id":63,"result":{"hash":"0x4f2a5...","nonce":"0x00",
"blockHash":"0x57698...","blockNumber":"0x2","transactionIndex":"0x0",
"from":"0x5c5a...","to":"0x","gas":"0x012118","gasPrice":"0x0ba43b7400",
"value":"0x","input":"0x608060405260..."}}

This fix checks if the byte array or the resulting string is empty and
if it is the case it returns 0x0 for the value or null for the address.
This fixes the issue with the remix IDE

According to https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethgettransactionreceipt, value must be a BigNumber, and "0x" seems not to be a valid BigNumber